### PR TITLE
Sorted export

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ Hierzu ist die Option `--compact` vorgesehen. Es können, je nach Datei, bis zu 
 Bei der Auflistung der Inhalte, kann die Option `--sorted` dazu verwendet werden, die angezeigten Einträge alphabetisch zu sortieren.
 Die Sortierung erfolgt dabei nach Namen des Katalogs oder des Formulars.
 
+##### Experimentell: Sortierung nach Modifikation
+
+Beim Modifizieren der Inhalte kann die experimentelle Option `--x-sorted` dazu verwendet werden, die Einträge im Anschluss an die Modifikation
+nach Namen zu sortieren.
+Dies erlaubt eine konsistente Reihenfolge der Einträge, wodurch ein direkter Vergleich mit Vorversionen ermöglicht wird.
+ACHTUNG: Es kann sein, dass dadurch ein Import der resultierenden OSC-Datei nicht mehr möglich ist, da das genaue Verhalten des Imports aktuell noch nicht bekannt ist.
+
 ## Profile
 
 Zum Erstellen von Varianten einer OSC-Datei wird eine Profildatei im YAML-Format verwendet.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,6 +52,11 @@ pub enum Command {
         outputfile: Option<String>,
         #[arg(long = "compact", help = "Kompakte Ausgabe, ohne Einrücken (Optional)")]
         compact: bool,
+        #[arg(
+            long = "x-sorted",
+            help = "EXPERIMENTELL: Sortiere Kataloge und Formulare nach Name (Optional). Kann negative Auswirkungen auf den ordnungsgemäßen Import haben."
+        )]
+        sorted: bool,
     },
     #[command(about = "Vergleiche zwei Dateien anhand der Revision der enthaltenen Inhalte")]
     Diff {

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             profile,
             outputfile,
             compact,
+            sorted,
         } => {
             let data = &mut read_inputfile(inputfile)?;
 
@@ -130,6 +131,10 @@ fn main() -> Result<(), Box<dyn Error>> {
                     FileError::Reading(profile, "Kann Profildatei nicht lesen!".into())
                 })?;
                 data.apply_profile(&profile);
+            }
+
+            if sorted {
+                data.sorted();
             }
 
             let mut buf = String::new();

--- a/src/model/data_catalogue.rs
+++ b/src/model/data_catalogue.rs
@@ -70,6 +70,16 @@ impl Sortable for DataCatalogue {
     fn sorting_key(&self) -> String {
         self.name.clone()
     }
+
+    fn sorted(&mut self) -> &Self {
+        self.entries
+            .entry
+            .sort_unstable_by_key(|item| item.sorting_key());
+        self.entries.entry.iter_mut().for_each(|item| {
+            item.sorted();
+        });
+        self
+    }
 }
 
 impl Comparable for DataCatalogue {
@@ -151,6 +161,23 @@ pub struct Entry {
     revision: u16,
 }
 
+impl Sortable for Entry {
+    fn sorting_key(&self) -> String {
+        self.name.clone()
+    }
+
+    fn sorted(&mut self) -> &Self
+    where
+        Self: Sized,
+    {
+        if let Some(ref mut use_) = self.use_ {
+            use_.program_module
+                .sort_unstable_by_key(|item| item.sorting_key())
+        }
+        self
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct Use {
@@ -165,4 +192,10 @@ pub struct ProgramModule {
     program: String,
     #[serde(rename = "@name")]
     name: String,
+}
+
+impl Sortable for ProgramModule {
+    fn sorting_key(&self) -> String {
+        format!("{}-{}", self.program, self.name)
+    }
 }

--- a/src/model/data_form.rs
+++ b/src/model/data_form.rs
@@ -192,6 +192,29 @@ impl Sortable for DataForm {
     fn sorting_key(&self) -> String {
         self.name.clone()
     }
+
+    fn sorted(&mut self) -> &Self {
+        self.data_catalogues.data_catalogue.sort_unstable();
+
+        self.entries
+            .entry
+            .sort_unstable_by_key(|item| item.sorting_key());
+
+        self.entries.entry.iter_mut().for_each(|item| {
+            item.sorted();
+        });
+
+        if let Some(ref mut plausibility_rule) = self.plausibility_rules.plausibility_rule {
+            plausibility_rule.sort_unstable_by_key(|item| item.bezeichnung.clone());
+
+            plausibility_rule.iter_mut().for_each(|item| {
+                if let Some(ref mut data_form_entry_names) = item.data_form_entries.entry_name {
+                    data_form_entry_names.sort_unstable();
+                }
+            });
+        }
+        self
+    }
 }
 
 impl Comparable for DataForm {
@@ -430,6 +453,26 @@ impl FormEntry for Entry {
             code: value,
             valid: true,
         });
+    }
+}
+
+impl Sortable for Entry {
+    fn sorting_key(&self) -> String {
+        self.name.clone()
+    }
+
+    fn sorted(&mut self) -> &Self
+    where
+        Self: Sized,
+    {
+        if let Some(ref mut filter) = self.filter {
+            if let Some(ref mut ref_entries) = filter.ref_entries {
+                if let Some(ref mut ref_entry) = ref_entries.ref_entry {
+                    ref_entry.sort_unstable()
+                }
+            }
+        }
+        self
     }
 }
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -239,6 +239,12 @@ pub trait Listable {
 
 pub trait Sortable {
     fn sorting_key(&self) -> String;
+    fn sorted(&mut self) -> &Self
+    where
+        Self: Sized,
+    {
+        self
+    }
 }
 
 pub trait Comparable: Debug {

--- a/src/model/onkostar_editor.rs
+++ b/src/model/onkostar_editor.rs
@@ -79,17 +79,33 @@ impl OnkostarEditor {
             .property_catalogue
             .sort_unstable_by_key(|e| e.sorting_key());
 
+        self.editor.property_catalogue.iter_mut().for_each(|item| {
+            item.sorted();
+        });
+
         self.editor
             .data_catalogue
             .sort_unstable_by_key(|e| e.sorting_key());
+
+        self.editor.data_catalogue.iter_mut().for_each(|item| {
+            item.sorted();
+        });
 
         self.editor
             .data_form
             .sort_unstable_by_key(|e| e.sorting_key());
 
+        self.editor.data_form.iter_mut().for_each(|item| {
+            item.sorted();
+        });
+
         self.editor
             .unterformular
             .sort_unstable_by_key(|e| e.sorting_key());
+
+        self.editor.unterformular.iter_mut().for_each(|item| {
+            item.sorted();
+        });
     }
 
     pub fn print_diff(&mut self, other: &mut Self, strict: bool) {
@@ -182,7 +198,7 @@ impl OnkostarEditor {
                         _ => {
                             if strict && entry_a.get_hash() != entry_b.get_hash() {
                                 println!(
-                                    "{}: {} (z.B. Reihenfolge von Unterelementen)",
+                                    "{}: {} (z.B. GUID oder Reihenfolge von Unterelementen)",
                                     entry_a.get_name(),
                                     style("Inhaltlich verschieden").yellow()
                                 );

--- a/src/model/unterformular.rs
+++ b/src/model/unterformular.rs
@@ -211,6 +211,29 @@ impl Sortable for Unterformular {
     fn sorting_key(&self) -> String {
         self.name.clone()
     }
+
+    fn sorted(&mut self) -> &Self {
+        self.data_catalogues.data_catalogue.sort_unstable();
+
+        self.entries
+            .entry
+            .sort_unstable_by_key(|item| item.sorting_key());
+
+        self.entries.entry.iter_mut().for_each(|item| {
+            item.sorted();
+        });
+
+        if let Some(ref mut plausibility_rule) = self.plausibility_rules.plausibility_rule {
+            plausibility_rule.sort_unstable_by_key(|item| item.bezeichnung.clone());
+
+            plausibility_rule.iter_mut().for_each(|item| {
+                if let Some(ref mut data_form_entry_names) = item.data_form_entries.entry_name {
+                    data_form_entry_names.sort_unstable();
+                }
+            });
+        }
+        self
+    }
 }
 
 impl Comparable for Unterformular {
@@ -450,6 +473,26 @@ impl FormEntry for Entry {
             code: value,
             valid: true,
         });
+    }
+}
+
+impl Sortable for Entry {
+    fn sorting_key(&self) -> String {
+        self.name.clone()
+    }
+
+    fn sorted(&mut self) -> &Self
+    where
+        Self: Sized,
+    {
+        if let Some(ref mut filter) = self.filter {
+            if let Some(ref mut ref_entries) = filter.ref_entries {
+                if let Some(ref mut ref_entry) = ref_entries.ref_entry {
+                    ref_entry.sort_unstable()
+                }
+            }
+        }
+        self
     }
 }
 


### PR DESCRIPTION
Sort items in file by name or other unique identifiers

This will reorder items that are usually in a different order after each change and export.