### PR TITLE
Hide form fields in OSC file using profile configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ In ihr sind die durchzuführenden Änderungen definiert. Eine Profildatei hat di
 ```
 forms:
   - name: "ExampleForm"
+    form_field:
+      - name: "formularfeld"
+        hide: true
     form_references:
       - name: "ref_first_mtb"
         referenced_data_form: "Formularverweis.Variante"
@@ -118,6 +121,12 @@ und dabei die vorhandenen Angaben für den Formularverweis zu ersetzen.
 
 Die Angaben für `referenced_data_form`, `anzeige_auswahl`, `anzeige` und `scripts_code` sind optional.
 Wird keine Angabe gemacht, wird der bestehende Wert beibehalten.
+
+Zudem wird im Formular "ExampleForm" das Formularfeld "formularfeld" ausgeblendet, indem der Filter auf "false" gesetzt wird.
+Dadurch wird das Formularfeld nie angezeigt.
+Ein zuvor bestehender Filter wird ersetzt.
+Weiterhin wird die Eigenschaft "Speichern" des Formularfelds auf "Immer speichern" gesetzt um sicherzustellen, dass zuvor
+enthaltene Daten weiterhin gespeichert bleiben und werden, auch wenn das Formularfeld nicht sichtbar ist.
 
 **Achtung!** Diese Anwendung überprüft keine Scripts und verwendet angegebene Scripts als "valid" im resultierenden OSC-File.
 

--- a/src/model/data_form.rs
+++ b/src/model/data_form.rs
@@ -31,7 +31,7 @@ use crate::model::onkostar_editor::OnkostarEditor;
 use crate::model::requirements::{Requirement, Requires};
 use crate::model::{
     apply_profile_to_form_entry, Ansichten, Comparable, Entries, Filter, FolderContent, FormEntry,
-    FormEntryContainer, Listable, MenuCategory, PlausibilityRules, Script, Sortable,
+    FormEntryContainer, Listable, MenuCategory, PlausibilityRules, RefEntries, Script, Sortable,
 };
 use crate::model::{Haeufigkeiten, Ordner};
 use crate::profile::Profile;
@@ -168,6 +168,13 @@ impl FormEntryContainer for DataForm {
                         .for_each(|form_reference| {
                             apply_profile_to_form_entry(entry, form_reference)
                         });
+
+                    // Hide form field using filter set to "false" if requested
+                    profile_form.form_fields.iter().for_each(|form_field| {
+                        if entry.name == form_field.name && form_field.hide {
+                            entry.hide()
+                        }
+                    });
 
                     if let Some(menu_category) = &profile_form.menu_category {
                         self.menu_category = Some(MenuCategory {
@@ -524,6 +531,14 @@ impl FormEntry for Entry {
             code: value,
             valid: true,
         });
+    }
+
+    fn hide(&mut self) {
+        self.filter = Some(Filter {
+            condition: "false".into(),
+            valid: true,
+            ref_entries: Some(RefEntries { ref_entry: None }),
+        })
     }
 }
 

--- a/src/model/data_form.rs
+++ b/src/model/data_form.rs
@@ -538,7 +538,8 @@ impl FormEntry for Entry {
             condition: "false".into(),
             valid: true,
             ref_entries: Some(RefEntries { ref_entry: None }),
-        })
+        });
+        self.speichern = "0".into()
     }
 }
 

--- a/src/model/data_form.rs
+++ b/src/model/data_form.rs
@@ -30,8 +30,9 @@ use serde::{Deserialize, Serialize};
 use crate::model::onkostar_editor::OnkostarEditor;
 use crate::model::requirements::{Requirement, Requires};
 use crate::model::{
-    apply_profile_to_form_entry, Ansichten, Comparable, Entries, Filter, FolderContent, FormEntry,
-    FormEntryContainer, Listable, MenuCategory, PlausibilityRules, RefEntries, Script, Sortable,
+    apply_profile_to_form_entry, apply_profile_to_form_field, Ansichten, Comparable, Entries,
+    Filter, FolderContent, FormEntry, FormEntryContainer, Listable, MenuCategory,
+    PlausibilityRules, RefEntries, Script, Sortable,
 };
 use crate::model::{Haeufigkeiten, Ordner};
 use crate::profile::Profile;
@@ -170,11 +171,10 @@ impl FormEntryContainer for DataForm {
                         });
 
                     // Hide form field using filter set to "false" if requested
-                    profile_form.form_fields.iter().for_each(|form_field| {
-                        if entry.name == form_field.name && form_field.hide {
-                            entry.hide()
-                        }
-                    });
+                    profile_form
+                        .form_fields
+                        .iter()
+                        .for_each(|form_field| apply_profile_to_form_field(entry, form_field));
 
                     if let Some(menu_category) = &profile_form.menu_category {
                         self.menu_category = Some(MenuCategory {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -267,6 +267,7 @@ pub trait FormEntry {
     fn update_anzeige(&mut self, value: String);
     fn update_anzeige_auswahl(&mut self, value: String);
     fn update_scripts_code(&mut self, value: String);
+    fn hide(&mut self);
 }
 
 pub trait FolderContent {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -28,7 +28,7 @@ use std::hash::{Hash, Hasher};
 
 use serde::{Deserialize, Serialize};
 
-use crate::profile::{FormReference, Profile};
+use crate::profile::{FormField, FormReference, Profile};
 
 pub mod data_catalogue;
 pub mod data_form;
@@ -229,6 +229,15 @@ where
         if let Some(scripts_code) = &form_reference.escaped_scripts_code() {
             entry.update_scripts_code(scripts_code.clone());
         }
+    }
+}
+
+fn apply_profile_to_form_field<E>(entry: &mut E, form_field: &FormField)
+where
+    E: FormEntry,
+{
+    if entry.get_name() == form_field.name && form_field.hide {
+        entry.hide()
     }
 }
 

--- a/src/model/unterformular.rs
+++ b/src/model/unterformular.rs
@@ -30,8 +30,9 @@ use serde::{Deserialize, Serialize};
 use crate::model::onkostar_editor::OnkostarEditor;
 use crate::model::requirements::{Requirement, Requires};
 use crate::model::{
-    apply_profile_to_form_entry, Ansichten, Comparable, Entries, Filter, FolderContent, FormEntry,
-    FormEntryContainer, Listable, MenuCategory, PlausibilityRules, RefEntries, Script, Sortable,
+    apply_profile_to_form_entry, apply_profile_to_form_field, Ansichten, Comparable, Entries,
+    Filter, FolderContent, FormEntry, FormEntryContainer, Listable, MenuCategory,
+    PlausibilityRules, RefEntries, Script, Sortable,
 };
 use crate::model::{Haeufigkeiten, Ordner};
 use crate::profile::Profile;
@@ -181,11 +182,10 @@ impl FormEntryContainer for Unterformular {
                         });
 
                     // Hide form field using filter set to "false" if requested
-                    profile_form.form_fields.iter().for_each(|form_field| {
-                        if entry.name == form_field.name && form_field.hide {
-                            entry.hide()
-                        }
-                    });
+                    profile_form
+                        .form_fields
+                        .iter()
+                        .for_each(|form_field| apply_profile_to_form_field(entry, form_field));
 
                     if let Some(menu_category) = &profile_form.menu_category {
                         self.menu_category = Some(MenuCategory {

--- a/src/model/unterformular.rs
+++ b/src/model/unterformular.rs
@@ -31,7 +31,7 @@ use crate::model::onkostar_editor::OnkostarEditor;
 use crate::model::requirements::{Requirement, Requires};
 use crate::model::{
     apply_profile_to_form_entry, Ansichten, Comparable, Entries, Filter, FolderContent, FormEntry,
-    FormEntryContainer, Listable, MenuCategory, PlausibilityRules, Script, Sortable,
+    FormEntryContainer, Listable, MenuCategory, PlausibilityRules, RefEntries, Script, Sortable,
 };
 use crate::model::{Haeufigkeiten, Ordner};
 use crate::profile::Profile;
@@ -179,6 +179,13 @@ impl FormEntryContainer for Unterformular {
                         .for_each(|form_reference| {
                             apply_profile_to_form_entry(entry, form_reference)
                         });
+
+                    // Hide form field using filter set to "false" if requested
+                    profile_form.form_fields.iter().for_each(|form_field| {
+                        if entry.name == form_field.name && form_field.hide {
+                            entry.hide()
+                        }
+                    });
 
                     if let Some(menu_category) = &profile_form.menu_category {
                         self.menu_category = Some(MenuCategory {
@@ -547,6 +554,14 @@ impl FormEntry for Entry {
             code: value,
             valid: true,
         });
+    }
+
+    fn hide(&mut self) {
+        self.filter = Some(Filter {
+            condition: "false".into(),
+            valid: true,
+            ref_entries: Some(RefEntries { ref_entry: None }),
+        })
     }
 }
 

--- a/src/model/unterformular.rs
+++ b/src/model/unterformular.rs
@@ -561,7 +561,8 @@ impl FormEntry for Entry {
             condition: "false".into(),
             valid: true,
             ref_entries: Some(RefEntries { ref_entry: None }),
-        })
+        });
+        self.speichern = "0".into()
     }
 }
 


### PR DESCRIPTION
This will hide form fields in user library forms if the following configuration is defined in profile file

```
...
forms:
  - name: 'Testform'
    form_fields:
      - name: 'testformfield'
        hide: true
...
```

If `hide` is set to `true`, the form fields filter condition will be set to `false` (evaluates to: do not show form field). In addition to this, it changes the save option to `0` to always save existing content on form save. This will keep existing or empty but invisible form field values.