### PR TITLE
feat: make property catalogue guid optional

### DIFF
--- a/src/model/property_catalogue.rs
+++ b/src/model/property_catalogue.rs
@@ -41,7 +41,8 @@ pub struct PropertyCatalogue {
     #[serde(rename = "SID")]
     sid: String,
     #[serde(rename = "GUID")]
-    guid: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    guid: Option<String>,
     #[serde(rename = "Revision")]
     revision: u16,
     #[serde(rename = "Versions")]


### PR DESCRIPTION
Since guid entry is not present in some basic property catalogues using export with complex property catalogues, it is expected to be missing in all property catalogues.