### PR TITLE
feat: add more verbose output

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Mit der Option `--filter` kann die Ausgabe eingeschränkt werden.
 
 *Bei Verwendung der OSB-Funktionalität kann die Eingabe eines Passworts erforderlich sein.*
 
+Die Option `-v` sorgt dafür, dass die eine Prüfsumme für Kataloge und Formulare berechnet und angezeigt wird.
+Dadurch können inhaltliche Unterschiede bei identischer Revisionsnummer erkannt werden.
+
 #### Unterbefehl `tree`
 
 Zum Auflisten der Inhalte mit allen Abhängigkeiten, z.B. Daten- und Merkmalskataloge und bei Formularen wird der Befehl
@@ -86,6 +89,9 @@ Für Formularverweise und Unterformulare werden dabei die verwendeten Datenkatal
 Achtung! Dies erzeugt eine sehr umfangreiche Ausgabe.
 
 Mit der Option `--filter` kann auch hier die Ausgabe eingeschränkt werden.
+
+Wie bei `list` sorgt auch hier die Option `-v` dafür,
+dass die eine Prüfsumme für Kataloge und Formulare berechnet und angezeigt wird.
 
 #### Unterbefehl `diff`
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,6 +27,9 @@ use clap_complete::Shell;
 pub struct Cli {
     #[command(subcommand)]
     pub cmd: SubCommand,
+
+    #[arg(short = 'v', global = true, help = "Zeige umfangreichere Ausgaben")]
+    pub verbose: bool,
 }
 
 #[derive(Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,6 @@ mod unzip_osb;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let cli = Cli::parse();
-    handle(cli.cmd)?;
+    handle(cli.cmd, cli.verbose)?;
     Ok(())
 }

--- a/src/model/data_catalogue.rs
+++ b/src/model/data_catalogue.rs
@@ -121,10 +121,14 @@ impl Requires for DataCatalogue {
         result
     }
 
-    fn to_requirement_string<'a>(&'a self, all: &'a OnkostarEditor) -> String {
+    fn to_requirement_string<'a>(&'a self, all: &'a OnkostarEditor, verbose: bool) -> String {
         format!(
             "{}\n{}",
-            self.to_listed_string(),
+            if verbose {
+                self.to_verbose_listed_string()
+            } else {
+                self.to_listed_string()
+            },
             self.get_required_entries(all)
                 .iter()
                 .filter_map(|entry| match entry {

--- a/src/model/form.rs
+++ b/src/model/form.rs
@@ -23,9 +23,9 @@ use crate::model::onkostar_editor::OnkostarEditor;
 use crate::model::other::Entry;
 use crate::model::requirements::{Requirement, Requires};
 use crate::model::{
-    apply_profile_to_form_entry, apply_profile_to_form_field, Ansichten, Comparable, Entries, FolderContent, FormEntry,
-    FormEntryContainer, Kennzahlen, Listable, MenuCategory, PlausibilityRules, PunkteKategorien,
-    Script, Sortable,
+    Ansichten, Comparable, Entries, FolderContent, FormEntry, FormEntryContainer, Kennzahlen,
+    Listable, MenuCategory, PlausibilityRules, PunkteKategorien, Script, Sortable,
+    apply_profile_to_form_entry, apply_profile_to_form_field,
 };
 use crate::model::{Haeufigkeiten, Ordner};
 use crate::profile::Profile;
@@ -250,7 +250,10 @@ impl<Type: 'static> FormEntryContainer for Form<Type> {
     }
 }
 
-impl<Type: 'static> Listable for Form<Type> {
+impl<Type: 'static> Listable for Form<Type>
+where
+    Form<Type>: Comparable,
+{
     fn to_listed_string(&self) -> String {
         format!(
             "{} ({}) '{}' in Revision '{}'",
@@ -673,8 +676,8 @@ pub struct DataFormEntries {
 mod tests {
     use std::str::FromStr;
 
-    use crate::model::onkostar_editor::OnkostarEditor;
     use crate::model::Script;
+    use crate::model::onkostar_editor::OnkostarEditor;
     use crate::profile::Profile;
 
     #[test]

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -18,15 +18,14 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+use crate::model::requirements::Requires;
+use crate::profile::{FormField, FormReference, Profile, WithScriptsCode};
+use console::style;
+use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
-
-use serde::{Deserialize, Serialize};
-
-use crate::model::requirements::Requires;
-use crate::profile::{FormField, FormReference, Profile, WithScriptsCode};
 
 pub mod data_catalogue;
 pub mod form;
@@ -354,8 +353,19 @@ pub trait FormEntryContainer {
     fn apply_profile(&mut self, profile: &Profile);
 }
 
-pub trait Listable {
+pub trait Listable
+where
+    Self: Comparable,
+{
     fn to_listed_string(&self) -> String;
+
+    fn to_verbose_listed_string(&self) -> String {
+        format!(
+            "{} {}",
+            self.to_listed_string(),
+            style(format!("[{}]", &self.get_hash()[..7])).dim()
+        )
+    }
 }
 
 pub trait Sortable {
@@ -375,7 +385,7 @@ pub trait Comparable: Debug {
     fn get_hash(&self) -> String {
         let mut h = DefaultHasher::new();
         format!("{self:?}").hash(&mut h);
-        h.finish().to_string()
+        format!("{:x}", h.finish())
     }
     fn compare_by_requirement(_: &Self, _: &Self) -> Ordering
     where

--- a/src/model/onkostar_editor.rs
+++ b/src/model/onkostar_editor.rs
@@ -114,17 +114,17 @@ impl OnkostarEditor {
             });
     }
 
-    pub fn print_list(&self) {
+    pub fn print_list(&self, verbose: bool) {
         println!(
             "Die Datei wurde am {} mit {} in Version {} erstellt.\n\nFolgende Inhalte sind gespeichert",
             style(&self.info_xml.datum_xml).yellow(),
             style(&self.info_xml.name).yellow(),
             style(&self.info_xml.version).yellow()
         );
-        Self::print_items("Merkmalskataloge", &self.editor.property_catalogue);
-        Self::print_items("Datenkataloge", &self.editor.data_catalogue);
-        Self::print_items("Formulare", &self.editor.data_form);
-        Self::print_items("Unterformulare", &self.editor.unterformular);
+        Self::print_items("Merkmalskataloge", &self.editor.property_catalogue, verbose);
+        Self::print_items("Datenkataloge", &self.editor.data_catalogue, verbose);
+        Self::print_items("Formulare", &self.editor.data_form, verbose);
+        Self::print_items("Unterformulare", &self.editor.unterformular, verbose);
     }
 
     fn filter_by_name_contains(&mut self, name: &str) {
@@ -141,7 +141,7 @@ impl OnkostarEditor {
             .unterformular
             .retain(|e| e.get_name().contains(name));
     }
-    pub fn print_list_filtered(&mut self, name: &str) {
+    pub fn print_list_filtered(&mut self, name: &str, verbose: bool) {
         println!(
             "Die Datei wurde am {} mit {} in Version {} erstellt.\n\nFolgende Inhalte für '{}' sind gespeichert",
             style(&self.info_xml.datum_xml).yellow(),
@@ -152,24 +152,28 @@ impl OnkostarEditor {
 
         self.filter_by_name_contains(name);
 
-        Self::print_items("Merkmalskataloge", &self.editor.property_catalogue);
-        Self::print_items("Datenkataloge", &self.editor.data_catalogue);
-        Self::print_items("Formulare", &self.editor.data_form);
-        Self::print_items("Unterformulare", &self.editor.unterformular);
+        Self::print_items("Merkmalskataloge", &self.editor.property_catalogue, verbose);
+        Self::print_items("Datenkataloge", &self.editor.data_catalogue, verbose);
+        Self::print_items("Formulare", &self.editor.data_form, verbose);
+        Self::print_items("Unterformulare", &self.editor.unterformular, verbose);
     }
 
-    fn print_items(title: &str, list: &[impl Listable]) {
+    fn print_items(title: &str, list: &[impl Listable], verbose: bool) {
         print!("\n{} {}", list.len(), style(title).underlined());
         println!(
             " - Inhalte der Systembibliothek sind mit ({}), der Benutzerbibliothek mit (u) markiert",
             style("S").yellow()
         );
         for entry in list {
+            if verbose {
+                println!("{}", entry.to_verbose_listed_string());
+                continue;
+            }
             println!("{}", entry.to_listed_string());
         }
     }
 
-    pub fn print_tree(&self) {
+    pub fn print_tree(&self, verbose: bool) {
         println!(
             "Die Datei wurde am {} mit {} in Version {} erstellt.\n\nFolgende Inhalte sind gespeichert",
             style(&self.info_xml.datum_xml).yellow(),
@@ -177,13 +181,13 @@ impl OnkostarEditor {
             style(&self.info_xml.version).yellow()
         );
 
-        Self::print_items("Merkmalskataloge", &self.editor.property_catalogue);
-        self.print_items_tree("Datenkataloge", &self.editor.data_catalogue);
-        self.print_items_tree("Formulare", &self.editor.data_form);
-        self.print_items_tree("Unterformulare", &self.editor.unterformular);
+        Self::print_items("Merkmalskataloge", &self.editor.property_catalogue, verbose);
+        self.print_items_tree("Datenkataloge", &self.editor.data_catalogue, verbose);
+        self.print_items_tree("Formulare", &self.editor.data_form, verbose);
+        self.print_items_tree("Unterformulare", &self.editor.unterformular, verbose);
     }
 
-    pub fn print_tree_filtered(&mut self, name: &str) {
+    pub fn print_tree_filtered(&mut self, name: &str, verbose: bool) {
         println!(
             "Die Datei wurde am {} mit {} in Version {} erstellt.\n\nFolgende Inhalte für '{}' sind gespeichert",
             style(&self.info_xml.datum_xml).yellow(),
@@ -194,20 +198,20 @@ impl OnkostarEditor {
 
         self.filter_by_name_contains(name);
 
-        Self::print_items("Merkmalskataloge", &self.editor.property_catalogue);
-        self.print_items_tree("Datenkataloge", &self.editor.data_catalogue);
-        self.print_items_tree("Formulare", &self.editor.data_form);
-        self.print_items_tree("Unterformulare", &self.editor.unterformular);
+        Self::print_items("Merkmalskataloge", &self.editor.property_catalogue, verbose);
+        self.print_items_tree("Datenkataloge", &self.editor.data_catalogue, verbose);
+        self.print_items_tree("Formulare", &self.editor.data_form, verbose);
+        self.print_items_tree("Unterformulare", &self.editor.unterformular, verbose);
     }
 
-    fn print_items_tree(&self, title: &str, list: &[impl Requires]) {
+    fn print_items_tree(&self, title: &str, list: &[impl Requires], verbose: bool) {
         print!("\n{} {}", list.len(), style(title).underlined());
         println!(
             " - Inhalte der Systembibliothek sind mit ({}), der Benutzerbibliothek mit (u) markiert",
             style("S").yellow()
         );
         for entry in list {
-            println!("{}", entry.to_requirement_string(self));
+            println!("{}", entry.to_requirement_string(self, verbose));
         }
     }
 

--- a/src/model/requirements.rs
+++ b/src/model/requirements.rs
@@ -110,10 +110,14 @@ where
 
     fn get_required_entries<'a>(&'a self, all: &'a OnkostarEditor) -> Vec<Requirement<'a>>;
 
-    fn to_requirement_string<'a>(&'a self, all: &'a OnkostarEditor) -> String {
+    fn to_requirement_string<'a>(&'a self, all: &'a OnkostarEditor, verbose: bool) -> String {
         format!(
             "{}\n{}",
-            self.to_listed_string(),
+            if verbose {
+                self.to_verbose_listed_string()
+            } else {
+                self.to_listed_string()
+            },
             self.get_required_entries(all)
                 .iter()
                 .filter_map(|entry| match entry {


### PR DESCRIPTION
Using `-v` the `list` and `tree` sub-command will show hash values based on catalogue or form contents.